### PR TITLE
Add GitHub link boxes to landing page and visualizer page

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, Cpu, GitBranch, Globe, Zap, Activity, Dna, Search, Network } from 'lucide-react';
+import { ArrowDown, Cpu, GitBranch, Globe, Zap, Activity, Dna, Search, Network, Github } from 'lucide-react';
 import BackgroundEffect from './BackgroundEffect';
 import React from 'react';
 import { Link } from 'react-router-dom';
@@ -14,6 +14,23 @@ const LandingPage: React.FC = () => {
 
   return (
     <div className="relative bg-[#0b1121] text-slate-200 font-sans selection:bg-blue-500/30 selection:text-blue-200">
+
+      {/* Fixed GitHub Link Box - Top Right Corner */}
+      <div className="fixed top-4 right-4 md:top-6 md:right-6 z-50">
+        <a
+          href="https://github.com/Astrasv/EvoViz"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group inline-flex items-center gap-2 md:gap-3 px-4 py-2.5 md:px-6 md:py-4 rounded-xl md:rounded-2xl bg-slate-900/80 border border-slate-800 backdrop-blur-sm hover:border-blue-500/40 hover:bg-slate-800/90 transition-all duration-300 shadow-[0_0_15px_rgba(59,130,246,0.2)] hover:shadow-[0_0_25px_rgba(59,130,246,0.3)] cursor-pointer"
+        >
+          <div className="p-1.5 md:p-2 rounded-lg md:rounded-xl bg-slate-950 border border-slate-800 group-hover:bg-blue-600 group-hover:border-blue-500 transition-all duration-300">
+            <Github className="w-4 h-4 md:w-5 md:h-5 text-slate-400 group-hover:text-white transition-colors" />
+          </div>
+          <span className="text-sm md:text-base text-slate-300 group-hover:text-white font-medium transition-colors hidden sm:inline">
+            View on GitHub
+          </span>
+        </a>
+      </div>
 
       {/* Fixed Background - Stays while scrolling */}
       <BackgroundEffect />

--- a/src/pages/VisualizerPage.tsx
+++ b/src/pages/VisualizerPage.tsx
@@ -11,6 +11,7 @@ import PopulationTable from '../components/PopulationTable';
 import Visualizer from '../components/Visualizer';
 import ConfigPanel from '../components/ConfigPanel';
 import StepLogView from '../components/StepLogView';
+import { Github } from 'lucide-react';
 import logo from '../assets/Evo-Viz-Logo.png';
 
 type Algorithm = 'GA' | 'DE' | 'PSO' | 'GP' | 'ES';
@@ -150,6 +151,19 @@ const VisualizerPage: React.FC = () => {
 
     return (
         <div className="min-h-screen bg-slate-900 text-slate-200 p-4 md:p-8 font-sans">
+            {/* Fixed GitHub Link - Bottom Right Corner */}
+            <div className="fixed bottom-4 right-4 md:bottom-6 md:right-6 z-50">
+                <a
+                    href="https://github.com/Astrasv/EvoViz"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group p-3 rounded-xl bg-slate-900/80 border border-slate-800 backdrop-blur-sm hover:border-blue-500/40 hover:bg-slate-800/90 transition-all duration-300 shadow-[0_0_15px_rgba(59,130,246,0.2)] hover:shadow-[0_0_25px_rgba(59,130,246,0.3)] cursor-pointer inline-flex items-center justify-center"
+                    title="View on GitHub"
+                >
+                    <Github className="w-5 h-5 text-slate-400 group-hover:text-white transition-colors" />
+                </a>
+            </div>
+
             <header className="mb-8 py-0.5 px-4 relative overflow-visible rounded-3xl border border-white/5 bg-slate-900/50 flex flex-col md:flex-row items-center justify-between gap-2">
                  <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none rounded-3xl">
                     <div className="absolute -top-24 -left-24 w-64 h-64 bg-blue-600/10 rounded-full blur-[80px]"></div>


### PR DESCRIPTION
<img width="1907" height="910" alt="image" src="https://github.com/user-attachments/assets/38308d38-19cb-42ef-8266-6abe8c2ab6fe" />
always stays on top right corner

<img width="1907" height="912" alt="image" src="https://github.com/user-attachments/assets/c4a64a7c-d776-4c51-be64-9110c85262f4" />
always stays on bottom right corner(it floats on top of everything else when you scroll)

fixes #22 